### PR TITLE
Fix TravisCI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
-sudo: false
-
 language: php
+
+services:
+  - mysql
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ notifications:
     on_success: never
     on_failure: change
 
-branches:
-  only:
-    - master
-
 cache:
   directories:
     - vendor


### PR DESCRIPTION
Adds `mysql` service to TravisCI config and removes
deprecated `sudo` key.

See: WordPress/phpunit-test-reporter#67