### PR TITLE
Update dependencies and readme for v0.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start with the latest WordPress image.
-FROM wordpress:5.3.2-php7.4
+FROM wordpress:5.4.1-php7.4
 
 # Set up nodejs PPA
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # PHPUnit Test Reporter #
-**Contributors:** octalmage, danielbachhuber, wpamitkumar, mikeschroder, pfefferle  
+**Contributors:** [octalmage](https://profiles.wordpress.org/octalmage), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [wpamitkumar](https://profiles.wordpress.org/wpamitkumar), [mikeschroder](https://profiles.wordpress.org/mikeschroder), [pfefferle](https://profiles.wordpress.org/pfefferle)  
 **Tags:** phpunit  
 **Requires at least:** 4.7  
 **Tested up to:** 5.4.1  
-**Stable tag:** 0.1.1  
+**Stable tag:** 0.1.2  
 **License:** GPLv3  
 **License URI:** http://www.gnu.org/licenses/gpl-3.0.html  
 
@@ -27,6 +27,14 @@ Usage:
 - `make shell`: SSH to Docker test environment.
 - `make test`: Runs `php-unit` and `phpcs` in Docker test environment.
 
+There is also a [Grunt](https://gruntjs.com/) command for updating the `README.md` file for Github
+after updating `readme.txt`.
+
+Usage:
+- `npm install`: Installs necessary dependencies.
+- `grunt readme`: Generates `README.md` with
+  `[grunt-wp-readme-to-markdown](https://github.com/stephenharris/wp-readme-to-markdown)`.
+
 ## Changelog ##
 
 ### 0.1.0 (August 21st, 2017) ###
@@ -37,3 +45,11 @@ Usage:
 * Update local and Travis CI builds.
 * Reduce number of revisions in index, while increasing max reporters shown.
 * Add contributor documentation.
+
+### 0.1.2 (May 18th, 2020) ###
+* Only report result status when tests were actually run. Port of
+  [meta #7227](https://meta.trac.wordpress.org/changeset/7227) to plugin.
+* Upgrade packages for `grunt readme` to Grunt ^1.1.0 and
+  grunt-wp-readme-to-markdown ^2.0.1, and update plugin version in `package.json`.
+* Upgrade Docker environment to use `wordpress:5.4.1-php7.4` image.
+* Correct contributor list in `readme.txt` and update `README.md`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phpunit-test-reporter",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/wordpress/phpunit-test-reporter.git"
@@ -8,7 +8,7 @@
   "main": "Gruntfile.js",
   "author": "WordPress Hosting Community <noreply@wordpress.org>",
   "devDependencies": {
-    "grunt": "^0.4.5",
-    "grunt-wp-readme-to-markdown": "~1.0.0"
+    "grunt": "^1.1.0",
+    "grunt-wp-readme-to-markdown": "^2.0.1"
   }
 }

--- a/phpunit-test-reporter.php
+++ b/phpunit-test-reporter.php
@@ -7,7 +7,7 @@
  * Author URI:      https://make.wordpress.org/hosting/
  * Text Domain:     ptr
  * Domain Path:     /languages
- * Version:         0.1.1
+ * Version:         0.1.2
  * License:         GPL v3
  *
  * @package         PTR

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === PHPUnit Test Reporter ===
-Contributors: octalmage, danielbachhuber, mikeschroder, pfefferle
+Contributors: octalmage, danielbachhuber, wpamitkumar, mikeschroder, pfefferle
 Tags: phpunit
 Requires at least: 4.7
 Tested up to: 5.4.1
-Stable tag: 0.1.1
+Stable tag: 0.1.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -27,6 +27,14 @@ Usage:
 - `make shell`: SSH to Docker test environment.
 - `make test`: Runs `php-unit` and `phpcs` in Docker test environment.
 
+There is also a [Grunt](https://gruntjs.com/) command for updating the `README.md` file for Github
+after updating `readme.txt`.
+
+Usage:
+- `npm install`: Installs necessary dependencies.
+- `grunt readme`: Generates `README.md` with
+  `[grunt-wp-readme-to-markdown](https://github.com/stephenharris/wp-readme-to-markdown)`.
+
 == Changelog ==
 
 = 0.1.0 (August 21st, 2017) =
@@ -37,3 +45,11 @@ Usage:
 * Update local and Travis CI builds.
 * Reduce number of revisions in index, while increasing max reporters shown.
 * Add contributor documentation.
+
+= 0.1.2 (May 18th, 2020) =
+* Only report result status when tests were actually run. Port of
+  [meta #7227](https://meta.trac.wordpress.org/changeset/7227) to plugin.
+* Upgrade packages for `grunt readme` to Grunt ^1.1.0 and
+  grunt-wp-readme-to-markdown ^2.0.1, and update plugin version in `package.json`.
+* Upgrade Docker environment to use `wordpress:5.4.1-php7.4` image.
+* Correct contributor list in `readme.txt` and update `README.md`.


### PR DESCRIPTION
* Upgrade packages for `grunt readme` to Grunt ^1.1.0 and
  grunt-wp-readme-to-markdown ^2.0.1, and update plugin version in `package.json`.
* Upgrade Docker environment to use `wordpress:5.4.1-php7.4` image.
* Correct contributor list in `readme.txt` and update `README.md`.
* Update version to 0.1.2.