### PR TITLE
Add `metadiff` command to `Makefile`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,13 @@ shell:
 
 test:
 	docker-compose exec wordpress /bin/bash -c "cd /var/www/html/wp-content/plugins/wp-unit-test-reporter/; phpcs --standard=phpcs.xml.dist ./ && phpunit"
+
+metadiff:
+	if [ -d "./build/wordpress.org" ]; then \
+		git -C ./build/wordpress.org reset --hard HEAD && \
+		git -C ./build/wordpress.org pull --rebase; \
+	else \
+		git clone https://github.com/WordPress/wordpress.org.git ./build/wordpress.org; \
+	fi
+	cp -rvp phpunit-test-reporter.php readme.txt src parts ./build/wordpress.org/wordpress.org/public_html/wp-content/plugins/phpunit-test-reporter
+	git -C ./build/wordpress.org diff --no-prefix > build/metadiff.diff


### PR DESCRIPTION
First run at adding a helper script for creating diffs for
updating the plugin in the meta repo.

Adding for discussion.

Is this actually useful / should it be in this repo?
If so, is this where it should live?