### PR TITLE
Ignore build directory when running `phpcs`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ shell:
 	docker-compose exec wordpress /bin/bash -c "cd /var/www/html/wp-content/plugins/wp-unit-test-reporter/; /bin/bash"
 
 test:
-	docker-compose exec wordpress /bin/bash -c "cd /var/www/html/wp-content/plugins/wp-unit-test-reporter/; phpcs --standard=phpcs.xml.dist ./ && phpunit"
+	docker-compose exec wordpress /bin/bash -c "cd /var/www/html/wp-content/plugins/wp-unit-test-reporter/; phpcs --standard=phpcs.xml.dist --ignore=build ./ && phpunit"
 
 metadiff:
 	if [ -d "./build/wordpress.org" ]; then \


### PR DESCRIPTION
After #80, `make test` started to fail following `make metadiff`.
This resolves the issue by ignoring the build directory when running `phpcs`.

See: #85