### PR TITLE
Change `commit` field type from `numeric` to `number`.

### DIFF
--- a/src/class-restapi.php
+++ b/src/class-restapi.php
@@ -19,10 +19,9 @@ class RestAPI {
 				'callback'            => array( __CLASS__, 'add_results_callback' ),
 				'args'                => array(
 					'commit'  => array(
-						'required'          => true,
-						'description'       => 'The SVN commit changeset number.',
-						'type'              => 'number',
-						'validate_callback' => array( __CLASS__, 'validate_callback' ),
+						'required'    => true,
+						'description' => 'The SVN commit changeset number.',
+						'type'        => 'number',
 					),
 					'results' => array(
 						'required'          => true,
@@ -50,17 +49,6 @@ class RestAPI {
 
 	public static function validate_callback( $value, $request, $key ) {
 		switch ( $key ) {
-			case 'commit':
-				if ( ! is_numeric( $value ) ) {
-					return new WP_Error(
-						'rest_invalid',
-						__( 'Value must be numeric.', 'ptr' ),
-						array(
-							'status' => 400,
-						)
-					);
-				}
-				return true;
 			case 'message':
 				if ( empty( $value ) || ! is_string( $value ) ) {
 					return new WP_Error(

--- a/src/class-restapi.php
+++ b/src/class-restapi.php
@@ -21,7 +21,7 @@ class RestAPI {
 					'commit'  => array(
 						'required'          => true,
 						'description'       => 'The SVN commit changeset number.',
-						'type'              => 'numeric',
+						'type'              => 'number',
 						'validate_callback' => array( __CLASS__, 'validate_callback' ),
 					),
 					'results' => array(

--- a/src/class-restapi.php
+++ b/src/class-restapi.php
@@ -21,7 +21,7 @@ class RestAPI {
 					'commit'  => array(
 						'required'    => true,
 						'description' => 'The SVN commit changeset number.',
-						'type'        => 'number',
+						'type'        => 'integer',
 					),
 					'results' => array(
 						'required'          => true,

--- a/tests/test-restapi.php
+++ b/tests/test-restapi.php
@@ -80,7 +80,7 @@ class TestRestAPI extends WP_UnitTestCase {
 		$this->assertEquals( 400, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertEquals( 'Invalid parameter(s): commit', $data['message'] );
-		$this->assertEquals( 'commit is not of type number.', $data['data']['params']['commit'] );
+		$this->assertEquals( 'commit is not of type integer.', $data['data']['params']['commit'] );
 	}
 
 	public function test_create_result_invalid_message() {

--- a/tests/test-restapi.php
+++ b/tests/test-restapi.php
@@ -80,7 +80,7 @@ class TestRestAPI extends WP_UnitTestCase {
 		$this->assertEquals( 400, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertEquals( 'Invalid parameter(s): commit', $data['message'] );
-		$this->assertEquals( 'Value must be numeric.', $data['data']['params']['commit'] );
+		$this->assertEquals( 'commit is not of type number.', $data['data']['params']['commit'] );
 	}
 
 	public function test_create_result_invalid_message() {


### PR DESCRIPTION
While validation is happening due to the [validation callback](https://github.com/WordPress/phpunit-test-reporter/blob/v0.1.2/src/class-restapi.php#L54), we started getting REST API deprecation notices because `numeric` is not a valid built-in type.

See: https://core.trac.wordpress.org/browser/tags/5.5.1/src/wp-includes/rest-api.php#L1583

This was causing the tests to fail.

This PR proposes changing to a type of `number` and letting WP's validation handle checking whether the value is numeric.