### PR TITLE
Add `CODE_OF_CONDUCT.md` and `CONTRIBUTING.md`

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,13 @@
+# Code of Conduct
+
+This project falls under the WordPress open source project, and follows [WordPress Etiquette](https://wordpress.org/about/etiquette/):
+
+In the WordPress open source project, we realize that our biggest asset is the community that we foster. The project, as a whole, follows these basic philosophical principles from [The Cathedral and The Bazaar](http://www.catb.org/esr/writings/cathedral-bazaar/cathedral-bazaar/).
+
+- Contributions to the WordPress open source project are for the benefit of the WordPress community as a whole, not specific businesses or individuals. All actions taken as a contributor should be made with the best interests of the community in mind.
+- Participation in the WordPress open source project is open to all who wish to join, regardless of ability, skill, financial status, or any other criteria.
+- The WordPress open source project is a volunteer-run community. Even in cases where contributors are sponsored by companies, that time is donated for the benefit of the entire open source community.
+- Any member of the community can donate their time and contribute to the project in any form including design, code, documentation, community building, etc. For more information, go to [make.wordpress.org](https://make.wordpress.org/).
+- The WordPress open source community cares about diversity. We strive to maintain a welcoming environment where everyone can feel included by keeping communication free of discrimination, incitement to violence, promotion of hate, and unwelcoming behavior.
+
+The team involved will be proactive in mitigating any breach of this.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-== Contributing Guidelines ==
+# Contributing Guidelines
 
 Thank you for considering contributing to the [WordPress PHPUnit Test Reporter](https://make.wordpress.org/hosting/test-results)! If you're unsure of anything, know that you're 💯 welcome to [submit an issue](https://github.com/phpunit-test-reporter/issues) or [pull request](https://github.com/phpunit-test-reporter/pulls) on any topic. The worst that can happen is that you'll be politely directed to the best location to ask your question or to change something in your pull request. We appreciate any sort of contribution and don't want a wall of rules to get in the way of that.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,3 +29,9 @@ Usage:
 - `npm install`: Installs necessary dependencies.
 - `grunt readme`: Generates `README.md` with
   [`grunt-wp-readme-to-markdown`](https://github.com/stephenharris/wp-readme-to-markdown).
+  
+## Coding Standards
+This project follows the [WordPress Coding Standards](https://github.com/WordPress/WordPress-Coding-Standards), and automatic checking is built into the automated tests.
+
+This means you can check locally with `make test` before submitting a PR, or on your fork/branch of the GitHub repo with TravisCI.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+== Contributing Guidelines ==
+
+Thank you for considering contributing to the [WordPress PHPUnit Test Reporter](https://make.wordpress.org/hosting/test-results)! If you're unsure of anything, know that you're 💯 welcome to [submit an issue](https://github.com/phpunit-test-reporter/issues) or [pull request](https://github.com/phpunit-test-reporter/pulls) on any topic. The worst that can happen is that you'll be politely directed to the best location to ask your question or to change something in your pull request. We appreciate any sort of contribution and don't want a wall of rules to get in the way of that.
+
+As with all WordPress projects, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](/CODE_OF_CONDUCT.md).
+
+This project is licensed [GPLv3](/LICENSE), and all contributions to this project will be released under the GPLv3 license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv3 license.
+
+This document covers the technical details around setup, and submitting your contribution.
+
+
+## Docker Environment
+There’s a Docker environment with several tools built in for testing.
+To configure it, run `make` and it will automatically run `docker-compose`.
+After that, to view the test environment, visit http://localhost:8080.
+
+Usage:
+- `make` or `make start`:  Builds a Docker environment for testing.
+- `make stop`: Stops Docker test environment.
+- `make shell`: SSH to Docker test environment.
+- `make test`: Runs `phpunit` and `phpcs` in the Docker test environment.
+
+
+## How to build `README.md`
+There is also a [Grunt](https://gruntjs.com/) command for updating the [`README.md`](/README.md) file for Github
+after updating [`readme.txt`](/readme.txt).
+
+Usage:
+- `npm install`: Installs necessary dependencies.
+- `grunt readme`: Generates `README.md` with
+  [`grunt-wp-readme-to-markdown`](https://github.com/stephenharris/wp-readme-to-markdown).

--- a/README.md
+++ b/README.md
@@ -13,27 +13,14 @@ Captures and displays test results from the PHPUnit Test Runner
 
 Captures and displays test results from the [PHPUnit Test Runner](https://github.com/WordPress/phpunit-test-runner).
 
+This is the plugin that receives and generates the results displayed on https://make.wordpress.org/hosting/test-results.
+
 For more details, [please read through the project overview](https://make.wordpress.org/hosting/test-results-getting-started/).
 
 ## Contributing ##
 
-There’s a Docker environment with several tools built in for testing.
-To configure it, run `make` and it will automatically run `docker-compose`.
-After that, to view the test environment, visit http://localhost:8080.
-
-Usage:
-- `make` or `make start`:  Builds a Docker environment for testing.
-- `make stop`: Stops Docker test environment.
-- `make shell`: SSH to Docker test environment.
-- `make test`: Runs `php-unit` and `phpcs` in Docker test environment.
-
-There is also a [Grunt](https://gruntjs.com/) command for updating the `README.md` file for Github
-after updating `readme.txt`.
-
-Usage:
-- `npm install`: Installs necessary dependencies.
-- `grunt readme`: Generates `README.md` with
-  `[grunt-wp-readme-to-markdown](https://github.com/stephenharris/wp-readme-to-markdown)`.
+Contributors are welcome!
+Check out the [contribution guidelines](https://github.com/WordPress/phpunit-test-reporter/blob/master/CONTRIBUTING.md) for details, including how to use the build/testing tools.
 
 ## Changelog ##
 

--- a/readme.txt
+++ b/readme.txt
@@ -13,27 +13,14 @@ Captures and displays test results from the PHPUnit Test Runner
 
 Captures and displays test results from the [PHPUnit Test Runner](https://github.com/WordPress/phpunit-test-runner).
 
+This is the plugin that receives and generates the results displayed on https://make.wordpress.org/hosting/test-results.
+
 For more details, [please read through the project overview](https://make.wordpress.org/hosting/test-results-getting-started/).
 
 == Contributing ==
 
-There’s a Docker environment with several tools built in for testing.
-To configure it, run `make` and it will automatically run `docker-compose`.
-After that, to view the test environment, visit http://localhost:8080.
-
-Usage:
-- `make` or `make start`:  Builds a Docker environment for testing.
-- `make stop`: Stops Docker test environment.
-- `make shell`: SSH to Docker test environment.
-- `make test`: Runs `php-unit` and `phpcs` in Docker test environment.
-
-There is also a [Grunt](https://gruntjs.com/) command for updating the `README.md` file for Github
-after updating `readme.txt`.
-
-Usage:
-- `npm install`: Installs necessary dependencies.
-- `grunt readme`: Generates `README.md` with
-  `[grunt-wp-readme-to-markdown](https://github.com/stephenharris/wp-readme-to-markdown)`.
+Contributors are welcome!
+Check out the [contribution guidelines](https://github.com/WordPress/phpunit-test-reporter/blob/master/CONTRIBUTING.md) for details, including how to use the build/testing tools.
 
 == Changelog ==
 


### PR DESCRIPTION
First pass.

Adds initial Code of Conduct and Contributing files, along
with minor changes in the readme files for linking and readability.

Code of Conduct based on https://github.com/WordPress/hosting-handbook/blob/master/CODE_OF_CONDUCT.md
Contributing file based on https://github.com/WordPress/wpdev-docker-images/blob/master/CONTRIBUTING.md

See #79.