### PR TITLE
Add a custom Post_List_Table for the results post type that lacks inline edit.

### DIFF
--- a/phpunit-test-reporter.php
+++ b/phpunit-test-reporter.php
@@ -30,6 +30,47 @@ add_action( 'post_class', array( 'PTR\Display', 'filter_post_class' ) );
 add_action( 'the_content', array( 'PTR\Display', 'filter_the_content' ) );
 add_action( 'rest_api_init', array( 'PTR\RestAPI', 'register_routes' ) );
 
+add_action( 'load-edit.php', 'ptr_load_edit_php' );
+
+/**
+ * Override the post type list table.
+ *
+ * The Results post type Quick Edit 'Page Parent' dropdown is tens of thousands of items long,
+ * and causes PHP OOM errors.
+ * This replaces it with a variant that doesn't support inline editing.. through a very non-conventional method.
+ */
+function ptr_load_edit_php() {
+	if ( ! isset( $_GET['post_type'] ) || 'result' != $_GET['post_type'] ) {
+		return;
+	}
+
+	// Load the core class.
+	_get_list_table( 'WP_Posts_List_Table' );
+	require_once dirname( __FILE__ ) . '/src/class-posts-list-table.php';
+
+	add_action( 'parse_request', 'ptr_override_results_list_table' );
+}
+
+/**
+ * Override the edit.php?post_type=results WP_Post_List_Table.
+ *
+ * This is the most ridiculous hack I've hacked, but this totally works.
+ */
+function ptr_override_results_list_table() {
+	global $wp_list_table;
+
+	if (
+		isset( $wp_list_table ) &&
+		'WP_Posts_List_Table' == get_class( $wp_list_table )
+	) {
+		remove_action( 'parse_request', __FUNCTION__ );
+
+		$wp_list_table = new PTR\Posts_List_Table();
+		// We were within WP_Posts_List_Table::prepare_items() when we overrode it, so we have to query again.
+		$wp_list_table->prepare_items();
+	}
+}
+
 /**
  * Get a rendered template part
  *

--- a/phpunit-test-reporter.php
+++ b/phpunit-test-reporter.php
@@ -44,9 +44,8 @@ function ptr_load_edit_php() {
 		return;
 	}
 
-	// Load the core class.
-	_get_list_table( 'WP_Posts_List_Table' );
-	require_once dirname( __FILE__ ) . '/src/class-posts-list-table.php';
+	require_once ABSPATH . 'wp-admin/includes/class-wp-posts-list-table.php';
+	require_once __DIR__ . '/src/class-posts-list-table.php';
 
 	add_action( 'parse_request', 'ptr_override_results_list_table' );
 }

--- a/src/class-posts-list-table.php
+++ b/src/class-posts-list-table.php
@@ -1,0 +1,23 @@
+<?php
+namespace PTR;
+
+use WP_Posts_List_Table;
+
+class Posts_List_Table extends WP_Posts_List_Table {
+
+	function __construct( $args = array() ) {
+		parent::__construct( $args );
+
+		add_filter( 'page_row_actions', [ $this, 'remove_quick_edit_link' ] );
+	}
+
+	function inline_edit() {
+		// silence is golden, no more OOM.
+	}
+
+	function remove_quick_edit_link( $links ) {
+		unset( $links['inline hide-if-no-js'] );
+		return $links;
+	}
+
+}


### PR DESCRIPTION
Fixes #100.

This is possibly the hackiest hack I've ever hacked.

This replaces the `$wp_list_table` global on the `edit.php?post_type=result` admin post listing screen with a variant that removes the quick edit/inline edit functionality for the post type.