### PR TITLE
Add additional report type for RTC performance data

### DIFF
--- a/src/class-content-model.php
+++ b/src/class-content-model.php
@@ -46,18 +46,15 @@ class Content_Model {
 		register_post_type(
 			'rtc-perf-result',
 			array(
-				'labels'       => array(
+				'labels'             => array(
 					'name'          => __( 'RTC Performance Results', 'ptr' ),
-					'singular_name' => __( 'RTCPerformance Result', 'ptr' ),
+					'singular_name' => __( 'RTC Performance Result', 'ptr' ),
 				),
-				'public'       => true,
-				'has_archive'  => false,
-				'show_in_rest' => true,
-				'hierarchical' => false,
-				'rewrite'      => array(
-					'slug' => 'rtc-perf-results',
-				),
-				'supports'     => array(
+				'public'             => false,
+				'show_ui'            => true,
+				'show_in_rest'       => true,
+				'hierarchical'       => false,
+				'supports'           => array(
 					'title',
 					'author',
 					'custom-fields',

--- a/src/class-content-model.php
+++ b/src/class-content-model.php
@@ -43,9 +43,31 @@ class Content_Model {
 			)
 		);
 
+		register_post_type(
+			'rtc-perf-result',
+			array(
+				'labels'       => array(
+					'name'          => __( 'RTC Performance Results', 'ptr' ),
+					'singular_name' => __( 'RTCPerformance Result', 'ptr' ),
+				),
+				'public'       => true,
+				'has_archive'  => false,
+				'show_in_rest' => true,
+				'hierarchical' => false,
+				'rewrite'      => array(
+					'slug' => 'rtc-perf-results',
+				),
+				'supports'     => array(
+					'title',
+					'author',
+					'custom-fields',
+				),
+			)
+		);
+
 		register_taxonomy(
 			'php-version',
-			array( 'result' ),
+			array( 'result', 'rtc-perf-result' ),
 			array(
 				'labels'       => array(
 					'name'          => __( 'PHP Versions', 'ptr' ),
@@ -63,7 +85,7 @@ class Content_Model {
 
 		register_taxonomy(
 			'db-version',
-			array( 'result' ),
+			array( 'result', 'rtc-perf-result' ),
 			array(
 				'labels'       => array(
 					'name'          => __( 'Database Versions', 'ptr' ),
@@ -96,6 +118,7 @@ class Content_Model {
 				'show_in_rest'               => true,
 			)
 		);
+
 	}
 
 	/**

--- a/src/class-restapi.php
+++ b/src/class-restapi.php
@@ -13,6 +13,30 @@ class RestAPI {
 	public static function register_routes() {
 		register_rest_route(
 			'wp-unit-test-api/v1',
+			'rtc-performance-results',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( __CLASS__, 'add_performance_results_callback' ),
+				'args'                => array(
+					'results' => array(
+						'required'          => true,
+						'description'       => 'Performance test results in JSON format.',
+						'type'              => 'string',
+						'validate_callback' => array( __CLASS__, 'validate_callback' ),
+					),
+					'env'     => array(
+						'required'          => true,
+						'description'       => 'JSON blob containing environment information.',
+						'type'              => 'string',
+						'validate_callback' => array( __CLASS__, 'validate_callback' ),
+					),
+				),
+				'permission_callback' => array( __CLASS__, 'permission' ),
+			)
+		);
+
+		register_rest_route(
+			'wp-unit-test-api/v1',
 			'results',
 			array(
 				'methods'             => 'POST',
@@ -93,6 +117,72 @@ class RestAPI {
 			);
 		}
 		return true;
+	}
+
+	public static function add_performance_results_callback( $data ) {
+		$parameters = $data->get_params();
+
+		$env     = json_decode( $parameters['env'], true );
+		$results = json_decode( $parameters['results'], true );
+
+		$php_version = '';
+		if ( ! empty( $env['php_version'] ) ) {
+			$parts       = explode( '.', $env['php_version'] );
+			$php_version = $parts[0] . '.' . $parts[1];
+		}
+
+		$db_version = ! empty( $env['mysql_version'] ) ? $env['mysql_version'] : '';
+		$wp_version = ! empty( $env['wp_version'] ) ? wp_kses( $env['wp_version'], [] ) : '';
+		$env_name   = ! empty( $env['label'] ) ? wp_kses( $env['label'], [] ) : '';
+
+		$current_user = wp_get_current_user();
+
+		$post_title = $current_user->user_login;
+		if ( $env_name ) {
+			$post_title .= ' - ' . $env_name;
+		}
+		if ( $wp_version ) {
+			$post_title .= ' - WP ' . $wp_version;
+		}
+		if ( $php_version ) {
+			$post_title .= ' - PHP ' . $php_version;
+		}
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => $post_title,
+				'post_content' => '',
+				'post_status'  => 'publish',
+				'post_author'  => $current_user->ID,
+				'post_type'    => 'rtc-perf-result',
+			),
+			true
+		);
+
+		if ( is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
+
+		if ( $php_version ) {
+			wp_set_object_terms( $post_id, array( $php_version ), 'php-version' );
+		}
+		if ( $db_version ) {
+			wp_set_object_terms( $post_id, array( $db_version ), 'db-version' );
+		}
+		update_post_meta( $post_id, 'env', $env );
+		update_post_meta( $post_id, 'results', $results );
+		update_post_meta( $post_id, 'environment_name', $env_name );
+
+		$response = new \WP_REST_Response(
+			array(
+				'id'   => $post_id,
+				'link' => get_permalink( $post_id ),
+			)
+		);
+		$response->set_status( 201 );
+		$response->header( 'Content-Type', 'application/json' );
+
+		return $response;
 	}
 
 	public static function add_results_callback( $data ) {


### PR DESCRIPTION
This adds support for a new test report type: RTC performance data.

In order to make a more informed decision about the right architecture for RTC-related data, there has been some exploration around providing a test script for hosts to run within their environments as a way to collect more data ([thread](https://wordpress.slack.com/archives/C07NVJ51X6K/p1776456404257239)). While this plugin is currently aimed solely at PHPUnit test reports, many hosts already have bot accounts available to them through this plugin and could easily run the new

In the future to make it more general and accept more types of data (E2E testing, performance testing, etc.), but this is a quick way to accept testing data short-term.