### PR TITLE
Fix real-time collaboration submissions failures

### DIFF
--- a/src/class-content-model.php
+++ b/src/class-content-model.php
@@ -54,6 +54,16 @@ class Content_Model {
 				'show_ui'            => true,
 				'show_in_rest'       => true,
 				'hierarchical'       => false,
+				'map_meta_cap'       => true,
+				'capabilities'       => array(
+					'edit_post'          => 'edit_rtc_perf_result',
+					'edit_posts'         => 'edit_rtc_perf_results',
+					'edit_others_posts'  => 'edit_others_rtc_perf_results',
+					'publish_posts'      => 'publish_rtc_perf_results',
+					'read_post'          => 'read_rtc_perf_result',
+					'read_private_posts' => 'read_private_rtc_perf_results',
+					'delete_post'        => 'delete_rtc_perf_result',
+				),
 				'supports'           => array(
 					'title',
 					'author',
@@ -135,6 +145,8 @@ class Content_Model {
 		if ( $role ) {
 			$role->add_cap( 'edit_results' );
 			$role->add_cap( 'publish_results' );
+			$role->add_cap( 'edit_rtc_perf_results' );
+			$role->add_cap( 'publish_rtc_perf_results' );
 		}
 		$role = get_role( 'administrator' );
 		if ( $role ) {
@@ -142,6 +154,10 @@ class Content_Model {
 			$role->add_cap( 'edit_others_results' );
 			$role->add_cap( 'publish_results' );
 			$role->add_cap( 'read_private_results' );
+			$role->add_cap( 'edit_rtc_perf_results' );
+			$role->add_cap( 'edit_others_rtc_perf_results' );
+			$role->add_cap( 'publish_rtc_perf_results' );
+			$role->add_cap( 'read_private_rtc_perf_results' );
 		}
 	}
 

--- a/src/class-restapi.php
+++ b/src/class-restapi.php
@@ -18,17 +18,21 @@ class RestAPI {
 				'methods'             => 'POST',
 				'callback'            => array( __CLASS__, 'add_performance_results_callback' ),
 				'args'                => array(
-					'results' => array(
-						'required'          => true,
-						'description'       => 'Performance test results in JSON format.',
-						'type'              => 'string',
-						'validate_callback' => array( __CLASS__, 'validate_callback' ),
+					'results'          => array(
+						'required'    => true,
+						'description' => 'Performance test results keyed by approach and scenario.',
+						'type'        => 'object',
 					),
-					'env'     => array(
-						'required'          => true,
-						'description'       => 'JSON blob containing environment information.',
+					'env'              => array(
+						'required'    => true,
+						'description' => 'Environment information for the test run.',
+						'type'        => 'object',
+					),
+					'environment_name' => array(
+						'required'          => false,
+						'description'       => 'Human-readable label for the environment under test.',
 						'type'              => 'string',
-						'validate_callback' => array( __CLASS__, 'validate_callback' ),
+						'sanitize_callback' => 'sanitize_text_field',
 					),
 				),
 				'permission_callback' => array( __CLASS__, 'permission' ),
@@ -122,8 +126,9 @@ class RestAPI {
 	public static function add_performance_results_callback( $data ) {
 		$parameters = $data->get_params();
 
-		$env     = json_decode( $parameters['env'], true );
-		$results = json_decode( $parameters['results'], true );
+		// env and results are decoded by the REST API when Content-Type is application/json.
+		$env     = is_array( $parameters['env'] ) ? $parameters['env'] : (array) json_decode( $parameters['env'], true );
+		$results = is_array( $parameters['results'] ) ? $parameters['results'] : (array) json_decode( $parameters['results'], true );
 
 		$php_version = '';
 		if ( ! empty( $env['php_version'] ) ) {
@@ -133,7 +138,14 @@ class RestAPI {
 
 		$db_version = ! empty( $env['mysql_version'] ) ? $env['mysql_version'] : '';
 		$wp_version = ! empty( $env['wp_version'] ) ? wp_kses( $env['wp_version'], [] ) : '';
-		$env_name   = ! empty( $env['label'] ) ? wp_kses( $env['label'], [] ) : '';
+
+		// Accept environment_name from the top-level parameter (preferred) or env['label'] (legacy).
+		$env_name = '';
+		if ( ! empty( $parameters['environment_name'] ) ) {
+			$env_name = wp_kses( $parameters['environment_name'], [] );
+		} elseif ( ! empty( $env['label'] ) ) {
+			$env_name = wp_kses( $env['label'], [] );
+		}
 
 		$current_user = wp_get_current_user();
 

--- a/src/class-restapi.php
+++ b/src/class-restapi.php
@@ -141,13 +141,7 @@ class RestAPI {
 		$db_version = ! empty( $env['mysql_version'] ) ? $env['mysql_version'] : '';
 		$wp_version = ! empty( $env['wp_version'] ) ? wp_kses( $env['wp_version'], [] ) : '';
 
-		// Accept environment_name from the top-level parameter (preferred) or env['label'] (legacy).
-		$env_name = '';
-		if ( ! empty( $parameters['environment_name'] ) ) {
-			$env_name = wp_kses( $parameters['environment_name'], [] );
-		} elseif ( ! empty( $env['label'] ) ) {
-			$env_name = wp_kses( $env['label'], [] );
-		}
+		$env_name = ! empty( $parameters['environment_name'] ) ? wp_kses( $parameters['environment_name'], [] ) : '';
 
 		$current_user = wp_get_current_user();
 

--- a/src/class-restapi.php
+++ b/src/class-restapi.php
@@ -19,14 +19,16 @@ class RestAPI {
 				'callback'            => array( __CLASS__, 'add_performance_results_callback' ),
 				'args'                => array(
 					'results'          => array(
-						'required'    => true,
-						'description' => 'Performance test results keyed by approach and scenario.',
-						'type'        => 'object',
+						'required'          => true,
+						'description'       => 'Performance test results keyed by approach and scenario.',
+						'type'              => 'object',
+						'validate_callback' => array( __CLASS__, 'validate_callback' ),
 					),
 					'env'              => array(
-						'required'    => true,
-						'description' => 'Environment information for the test run.',
-						'type'        => 'object',
+						'required'          => true,
+						'description'       => 'Environment information for the test run.',
+						'type'              => 'object',
+						'validate_callback' => array( __CLASS__, 'validate_callback' ),
 					),
 					'environment_name' => array(
 						'required'          => false,
@@ -90,7 +92,7 @@ class RestAPI {
 				return true;
 			case 'env':
 			case 'results':
-				if ( null === json_decode( $value ) ) {
+				if ( is_string( $value ) && null === json_decode( $value ) ) {
 					return new WP_Error(
 						'rest_invalid',
 						__( 'Value must be encoded JSON.', 'ptr' ),

--- a/src/class-restapi.php
+++ b/src/class-restapi.php
@@ -139,9 +139,9 @@ class RestAPI {
 		}
 
 		$db_version = ! empty( $env['mysql_version'] ) ? $env['mysql_version'] : '';
-		$wp_version = ! empty( $env['wp_version'] ) ? wp_kses( $env['wp_version'], [] ) : '';
+		$wp_version = ! empty( $env['wp_version'] ) ? strip_tags( $env['wp_version'] ) : '';
 
-		$env_name = ! empty( $parameters['environment_name'] ) ? wp_kses( $parameters['environment_name'], [] ) : '';
+		$env_name = ! empty( $parameters['environment_name'] ) ? strip_tags( $parameters['environment_name'] ) : '';
 
 		$current_user = wp_get_current_user();
 


### PR DESCRIPTION
This adds meta capability mapping to the new test result type added in #118. Because this is missing, submissions are currently being rejected.

Also in this PR:
- Ensure that all fields are handled correctly based on their expected type.
- Guard against non-string values in `validate_callback`
- Ensure environment name is acutally processed.
- Replace `wp_kses( $var, [] )` with `strip_tags()`.